### PR TITLE
Makefile: Use wildcard in target rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 VERSION = 1.0.1
 TARGET  = imobax
-SRCDIR  = src
+OBJS    = $(wildcard src/*.c)
 FLAGS  ?= -Wall -O3 -DVERSION=$(VERSION) -DTIMESTAMP="`date +'%d. %B %Y %H:%M:%S'`" -flto -lsqlite3 $(CFLAGS)
 
 .PHONY: all clean
 
 all: $(TARGET)
 
-$(TARGET): $(SRCDIR)/*.c
+$(TARGET): $(OBJS)
 	$(CC) -o $@ $^ $(FLAGS)
 
 clean:


### PR DESCRIPTION
This small PR includes a QOL update to the Makefile, which renames `SRCDIR` to `OBJS` and points it to the source files using a wildcard.